### PR TITLE
#159032365 User should join a game once

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -47,6 +47,7 @@
     "describe": true,
     "before": true,
     "it": true,
-    "$": true
+    "$": true,
+    "should": true
   }
 }

--- a/app/middleware/auth.js
+++ b/app/middleware/auth.js
@@ -8,11 +8,12 @@ import jwt from 'jsonwebtoken';
 
 const auth = (req, res, next) => {
   let token = req.headers.authorization || req.headers['x-access-token'];
-  token = token.replace('Bearer ', '');
 
   if (!token) {
     return res.status(401).json({ message: 'Unauthorized Access' });
   }
+
+  token = token.replace('Bearer ', '');
 
   jwt.verify(token, process.env.SECRET_KEY, (err, result) => {
     if (err) {

--- a/backend-test/game/game.js
+++ b/backend-test/game/game.js
@@ -1,7 +1,12 @@
-/* eslint no-undef: 0 */
-import should from 'should';
+
 import io from 'socket.io-client';
+import request from 'supertest';
+import { expect } from 'chai';
+import mongoose from 'mongoose';
 import config from '../../config/config';
+import app from '../../server';
+
+const User = mongoose.model('User');
 
 const socketURL = `http://localhost:${config.port}`;
 
@@ -11,30 +16,97 @@ const options = {
   'force new connection': true
 };
 
-const cfhPlayer1 = { name: 'Tom' };
-const cfhPlayer2 = { name: 'Sally' };
-const cfhPlayer3 = { name: 'Dana' };
+const userMock = {
+  name: 'kelvin8',
+  password: '123456',
+  username: 'kelvin8',
+  email: 'kelvin8@email.com'
+};
+let userId;
 
 describe('Game Server', () => {
+  before(() => {
+    Promise.resolve(User.remove({}));
+  });
+
+  it('POST /api/auth/signup should return the userId', (done) => {
+    request(app)
+      .post('/api/auth/signup')
+      .send(userMock)
+      .end((err, res) => {
+        if (err) return done(err);
+        expect(res.statusCode).to.equal(201);
+        userId = res.body._id;
+        done();
+      });
+  });
+
   it('Should accept requests to joinGame', (done) => {
     const client1 = io.connect(socketURL, options);
     const disconnect = () => {
       client1.disconnect();
       done();
     };
-    client1.on('connect', (data) => {
-      client1.emit('joinGame', { userID: 'unauthenticated', room: '', createPrivate: false });
+    client1.on('connect', () => {
+      client1.emit('joinGame', { userId, room: '', createPrivate: false });
       setTimeout(disconnect, 200);
+    });
+  });
+
+  it('Authenticated user should joinGame once', (done) => {
+    const client1 = io.connect(socketURL, options);
+    let client2;
+    const disconnect = () => {
+      client1.disconnect();
+      client2.disconnect();
+      done();
+    };
+    client1.on('connect', () => {
+      client1.emit('joinGame', { userId, room: '', createPrivate: false });
+      client1.on('gameUpdate', (data) => {
+        expect(data.players.length).to.equal(1);
+      });
+      client2 = io.connect(socketURL, options);
+      client2.on('connect', () => {
+        client2.emit('joinGame', { userId, room: '', createPrivate: false });
+        client2.on('gameUpdate', (data) => {
+          expect(data.players.length).to.equal(1);
+        });
+      });
+      setTimeout(disconnect, 500);
+    });
+  });
+
+  it('UnAuthenticated user can join a game more than once', (done) => {
+    const client1 = io.connect(socketURL, options);
+    let client2;
+    const disconnect = () => {
+      client1.disconnect();
+      client2.disconnect();
+      done();
+    };
+    client1.on('connect', () => {
+      client1.emit('joinGame', { userId: 'unauthenticated', room: '', createPrivate: false });
+      client1.on('gameUpdate', (data) => {
+        expect(data.players.length).to.equal(1);
+      });
+      client2 = io.connect(socketURL, options);
+      client2.on('connect', () => {
+        client2.on('gameUpdate', (data) => {
+          expect(data.players.length).to.equal(2);
+        });
+      });
+      setTimeout(disconnect, 500);
     });
   });
 
   it('Should send a game update upon receiving request to joinGame', (done) => {
     const client1 = io.connect(socketURL, options);
-    const disconnect = () =>  {
+    const disconnect = () => {
       client1.disconnect();
       done();
     };
-    client1.on('connect', (data) => {
+    client1.on('connect', () => {
       client1.emit('joinGame', { userID: 'unauthenticated', room: '', createPrivate: false });
       client1.on('gameUpdate', (data) => {
         data.gameID.should.match(/\d+/);
@@ -51,11 +123,11 @@ describe('Game Server', () => {
       client2.disconnect();
       done();
     };
-    client1.on('connect', (data) => {
-      client1.emit('joinGame', { userID: 'unauthenticated', room: '', createPrivate: false });
+    client1.on('connect', () => {
+      client1.emit('joinGame', { userId: 'unauthenticated', room: '', createPrivate: false });
       client2 = io.connect(socketURL, options);
-      client2.on('connect', (data) => {
-        client2.emit('joinGame', { userID: 'unauthenticated', room: '', createPrivate: false });
+      client2.on('connect', () => {
+        client2.emit('joinGame', { userId: 'unauthenticated', room: '', createPrivate: false });
         client1.on('notification', (data) => {
           data.notification.should.match(/ has joined the game\!/);
         });
@@ -65,8 +137,8 @@ describe('Game Server', () => {
   });
 
   it('Should start game when startGame event is sent with 3 players', (done) => {
-    let client1, client2, client3;
-    client1 = io.connect(socketURL, options);
+    let client2, client3;
+    const client1 = io.connect(socketURL, options);
     const disconnect = () => {
       client1.disconnect();
       client2.disconnect();
@@ -86,13 +158,13 @@ describe('Game Server', () => {
       });
       setTimeout(disconnect, 200);
     };
-    client1.on('connect', (data) => {
+    client1.on('connect', () => {
       client1.emit('joinGame', { userID: 'unauthenticated', room: '', createPrivate: false });
       client2 = io.connect(socketURL, options);
-      client2.on('connect', (data) => {
+      client2.on('connect', () => {
         client2.emit('joinGame', { userID: 'unauthenticated', room: '', createPrivate: false });
         client3 = io.connect(socketURL, options);
-        client3.on('connect', (data) => {
+        client3.on('connect', () => {
           client3.emit('joinGame', { userID: 'unauthenticated', room: '', createPrivate: false });
           setTimeout(expectStartGame, 100);
         });
@@ -101,8 +173,8 @@ describe('Game Server', () => {
   });
 
   it('Should automatically start game when 6 players are in a game', (done) => {
-    let client1, client2, client3, client4, client5, client6;
-    client1 = io.connect(socketURL, options);
+    let client2, client3, client4, client5, client6;
+    const client1 = io.connect(socketURL, options);
     const disconnect = () => {
       client1.disconnect();
       client2.disconnect();
@@ -112,7 +184,7 @@ describe('Game Server', () => {
       client6.disconnect();
       done();
     };
-    const expectStartGame =  () => {
+    const expectStartGame = () => {
       client1.emit('startGame');
       client1.on('gameUpdate', (data) => {
         data.state.should.equal('waiting for players to pick');
@@ -134,29 +206,29 @@ describe('Game Server', () => {
       });
       setTimeout(disconnect, 200);
     };
-    client1.on('connect', (data) => {
+    client1.on('connect', () => {
       client1.emit('joinGame', { userID: 'unauthenticated', room: '', createPrivate: true });
       let connectOthers = true;
       client1.on('gameUpdate', (data) => {
-        const gameID = data.gameID;
+        const { gameID } = data;
         if (connectOthers) {
           client2 = io.connect(socketURL, options);
           connectOthers = false;
-          client2.on('connect', (data) => {
+          client2.on('connect', () => {
             client2.emit('joinGame', { userID: 'unauthenticated', room: gameID, createPrivate: false });
             client3 = io.connect(socketURL, options);
-            client3.on('connect', (data) => {
+            client3.on('connect', () => {
               client3.emit('joinGame', { userID: 'unauthenticated', room: gameID, createPrivate: false });
               client4 = io.connect(socketURL, options);
-              client4.on('connect', (data) => {
+              client4.on('connect', () => {
                 client4.emit('joinGame', { userID: 'unauthenticated', room: gameID, createPrivate: false });
                 client5 = io.connect(socketURL, options);
-                client5.on('connect', (data) => {
-                  client5.emit('joinGame',{userID:'unauthenticated',room: gameID, createPrivate: false});
+                client5.on('connect', () => {
+                  client5.emit('joinGame', { userID: 'unauthenticated', room: gameID, createPrivate: false });
                   client6 = io.connect(socketURL, options);
-                  client6.on('connect', (data) => {
-                    client6.emit('joinGame',{userID:'unauthenticated',room: gameID, createPrivate: false});
-                    setTimeout(expectStartGame,100);
+                  client6.on('connect', () => {
+                    client6.emit('joinGame', { userID: 'unauthenticated', room: gameID, createPrivate: false });
+                    setTimeout(expectStartGame, 100);
                   });
                 });
               });

--- a/config/socket/socket.js
+++ b/config/socket/socket.js
@@ -3,6 +3,7 @@ eslint prefer-arrow-callback: 0, func-names: 0, no-undef: 0, no-var: 0,
 vars-on-top: 0, import/no-dynamic-require: 0, prefer-template: 0, no-path-concat: 0,
 no-console: 0, no-use-before-define: 0, no-shadow: 0, no-plusplus: 0,
 block-scoped-var: 0, prefer-destructuring: 0, no-redeclare: 0,
+array-callback-return: 0
 */
 
 var mongoose = require('mongoose');
@@ -87,7 +88,7 @@ module.exports = function (io) {
     if (data.userId !== 'unauthenticated') {
       User.findOne({
         _id: data.userId
-      }).exec(function(err, user) {
+      }).exec(function (err, user) {
         if (err) {
           console.log('err', err);
           return err; // Hopefully this never happens.
@@ -174,7 +175,11 @@ module.exports = function (io) {
     } else {
       game = gamesNeedingPlayers[0];
       allPlayers[socket.id] = true;
-
+      // const isUserExist = game.players.map(user => user.userId === player.userId);
+      const isUserExist = game.players.find(user => user.userId === player.userId);
+      if (isUserExist && player.userId !== 'unauthenticated') {
+        return io.sockets.socket(socket.id).emit('userExist');
+      }
       if (game.players.length < game.playerMaxLimit) {
         if (game.players.length === (game.playerMaxLimit - 1)) game.pending = true;
         return setUpGame(socket, game, player);
@@ -197,6 +202,7 @@ module.exports = function (io) {
       io.sockets.socket(socket.id).emit('gameFilledUp');
     }
   };
+
   const setUpGame = (socket, game, player) => {
     game.players.push(player);
     socket.join(game.gameID);

--- a/public/js/controllers/game.js
+++ b/public/js/controllers/game.js
@@ -158,6 +158,18 @@ angular.module('mean.system')
       }
     });
 
+    $scope.$watch('game.userExist', function () {
+      var reUsableModal = $('#reuse-modal');
+      $('.modal-header').empty();
+      reUsableModal.find('.modal-header').append('<h4 class="modal-title center-align" style="color: #23522d;">You Cannot Join A Game Twice</h4>');
+      $('.modal-body').empty();
+      reUsableModal.find('.modal-body').append('<p>You have already joined this game</p>');
+      var okayBtn = '<a href="/" class="btn" style="background-color: #23522d;">OKAY</a>';
+      $('.modal-footer').empty();
+      $('.modal-footer').append(okayBtn);
+      $('#reuse-modal').modal('open');
+    });
+
     $scope.abandonGame = function () {
       game.leaveGame();
       $location.path('/');

--- a/public/js/controllers/invitePlayers.js
+++ b/public/js/controllers/invitePlayers.js
@@ -18,7 +18,7 @@ angular.module('mean.system')
       $('#reuse-modal').modal('close');
       game.isFilledUp = null;
     };
-      
+  
     $scope.findUsers = function () {
       return $http.get(`/api/users/findUsers/${$scope.searchKey}`, { headers: { Authorization: `Bearer ${token}` } }).then(function (response) {
         $scope.foundUsers = response.data.users;

--- a/public/js/services/game.js
+++ b/public/js/services/game.js
@@ -70,6 +70,10 @@ angular.module('mean.system')
       game.isFilledUp = true;
     });
 
+    socket.on('userExist', function () {
+      game.userExist = true;
+    });
+
     socket.on('gameUpdate', function (data) {
     // Update gameID field only if it changed.
     // That way, we don't trigger the $scope.$watch too often
@@ -191,7 +195,7 @@ angular.module('mean.system')
     game.startGame = function () {
       socket.emit('startGame');
     };
-    game.createPlayers = function(gameId, players) {
+    game.createPlayers = function (gameId, players) {
       const token = localStorage.getItem('#cfhetusertoken');
       $http({
         method: 'POST',
@@ -201,12 +205,11 @@ angular.module('mean.system')
         },
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': token,
+          Authorization: token,
         }
-      }).then(gamePlayers => {
-        console.log(gamePlayers);
-      });
-    }
+      }).then(gamePlayers => gamePlayers);
+    };
+
     game.leaveGame = function () {
       game.players = [];
       game.time = 0;


### PR DESCRIPTION

#### What does this PR do?
Restrict authenticated user to join a game twice
#### Description of Task to be completed?
Prevents signed in users from joining the same game session twice
Pops up a modal to warn a user that he/she cant join a game twice
Redirect the user to the homepage 
#### How should this be manually tested?
Navigate to staging branch on Heroku login and start a game twice using the same user info. A modal will pop warning you that you can't join a game twice
#### What are the relevant pivotal tracker stories?
[#159032365]

#### Any background context you want to add?

#### Screenshots
<img width="1304" alt="screen shot 2018-07-17 at 10 21 09 am" src="https://user-images.githubusercontent.com/28547970/42808469-4e9adba8-89ab-11e8-9b41-cc392a49b210.png">
